### PR TITLE
Introduces identifier

### DIFF
--- a/fakes/image.go
+++ b/fakes/image.go
@@ -18,12 +18,12 @@ import (
 	"github.com/buildpack/imgutil"
 )
 
-func NewImage(name, topLayerSha, digest string) *Image {
+func NewImage(name, topLayerSha string, identifier imgutil.Identifier) *Image {
 	return &Image{
 		labels:        map[string]string{},
 		env:           map[string]string{},
 		topLayerSha:   topLayerSha,
-		digest:        digest,
+		identifier:    identifier,
 		name:          name,
 		cmd:           []string{"initialCMD"},
 		layersMap:     map[string]string{},
@@ -42,7 +42,7 @@ type Image struct {
 	labels        map[string]string
 	env           map[string]string
 	topLayerSha   string
-	digest        string
+	identifier    imgutil.Identifier
 	name          string
 	entryPoint    []string
 	cmd           []string
@@ -69,8 +69,8 @@ func (i *Image) Name() string {
 	return i.name
 }
 
-func (i *Image) Digest() (string, error) {
-	return i.digest, nil
+func (i *Image) Identifier() (imgutil.Identifier, error) {
+	return i.identifier, nil
 }
 
 func (i *Image) Rebase(baseTopLayer string, newBase imgutil.Image) error {
@@ -185,8 +185,6 @@ func (i *Image) Save(additionalNames ...string) error {
 		}
 	}
 
-	i.digest = i.digest + "-saved"
-
 	if len(errs) > 0 {
 		return imgutil.SaveError{Errors: errs}
 	}
@@ -224,6 +222,10 @@ func (i *Image) Found() bool {
 }
 
 // test methods
+
+func (i *Image) SetIdentifier(identifier imgutil.Identifier) {
+	i.identifier = identifier
+}
 
 func (i *Image) Cleanup() error {
 	return os.RemoveAll(i.layerDir)

--- a/fakes/image_test.go
+++ b/fakes/image_test.go
@@ -41,7 +41,7 @@ func testFake(t *testing.T, when spec.G, it spec.S) {
 			)
 
 			it("returns list of saved names", func() {
-				image := fakes.NewImage(repoName, "", "")
+				image := fakes.NewImage(repoName, "", nil)
 
 				_ = image.Save(additionalNames...)
 
@@ -53,7 +53,7 @@ func testFake(t *testing.T, when spec.G, it spec.S) {
 				it("returns a list of image names with errors", func() {
 					badImageName := repoName + ":🧨"
 
-					image := fakes.NewImage(repoName, "", "")
+					image := fakes.NewImage(repoName, "", nil)
 
 					err := image.Save(append([]string{badImageName}, additionalNames...)...)
 					saveErr, ok := err.(imgutil.SaveError)

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/go-containerregistry v0.0.0-20190110221225-f514e780f7cd h1:u7HssFPC/BNGAttHPr1mcz5lWlqLlvV99SqrulqNhXY=
-github.com/google/go-containerregistry v0.0.0-20190110221225-f514e780f7cd/go.mod h1:yZAFP63pRshzrEYLXLGPmUt0Ay+2zdjmMN1loCnRLUk=
 github.com/google/go-containerregistry v0.0.0-20190503220729-1c6c7f61e8a5 h1:wXZCVr9/0naJbZhAzKDzj/sgnduf8qn9ldjkI/CND9k=
 github.com/google/go-containerregistry v0.0.0-20190503220729-1c6c7f61e8a5/go.mod h1:yZAFP63pRshzrEYLXLGPmUt0Ay+2zdjmMN1loCnRLUk=
 github.com/gorilla/mux v1.7.1 h1:Dw4jY2nghMMRsh1ol8dv1axHkDwMQK2DHerMNJsIpJU=
@@ -69,8 +67,6 @@ golang.org/x/net v0.0.0-20190415214537-1da14a5a36f2/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190412183630-56d357773e84 h1:IqXQ59gzdXv58Jmm2xn0tSOR9i6HqroaOFRQ3wR/dJQ=
-golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/image.go
+++ b/image.go
@@ -26,7 +26,6 @@ func (e SaveError) Error() string {
 type Image interface {
 	Name() string
 	Rename(name string)
-	Digest() (string, error)
 	Label(string) (string, error)
 	SetLabel(string, string) error
 	Env(key string) (string, error)
@@ -45,4 +44,7 @@ type Image interface {
 	GetLayer(sha string) (io.ReadCloser, error)
 	Delete() error
 	CreatedAt() (time.Time, error)
+	Identifier() (Identifier, error)
 }
+
+type Identifier fmt.Stringer

--- a/local/identifier.go
+++ b/local/identifier.go
@@ -1,0 +1,9 @@
+package local
+
+type IDIdentifier struct {
+	ImageID string
+}
+
+func (i IDIdentifier) String() string {
+	return i.ImageID
+}

--- a/remote/identifier.go
+++ b/remote/identifier.go
@@ -1,0 +1,13 @@
+package remote
+
+import (
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+type DigestIdentifier struct {
+	Digest name.Digest
+}
+
+func (d DigestIdentifier) String() string {
+	return d.Digest.String()
+}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -162,12 +162,20 @@ func (i *Image) Found() bool {
 	return true
 }
 
-func (i *Image) Digest() (string, error) {
+func (i *Image) Identifier() (imgutil.Identifier, error) {
 	hash, err := i.image.Digest()
 	if err != nil {
-		return "", fmt.Errorf("failed to get digest for image '%s': %s", i.repoName, err)
+		return nil, fmt.Errorf("failed to get digest for image '%s': %s", i.repoName, err)
 	}
-	return hash.String(), nil
+
+	digestRef, err := name.NewDigest(i.repoName+"@"+hash.String(), name.WeakValidation)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating digest reference")
+	}
+
+	return DigestIdentifier{
+		Digest: digestRef,
+	}, nil
 }
 
 func (i *Image) CreatedAt() (time.Time, error) {


### PR DESCRIPTION
* local image uses image ID as identifier
* remote image uses Digest as identifier

Signed-off-by: Javier Romero <jromero@pivotal.io>
Signed-off-by: Emily Casey <ecasey@pivotal.io>