### PR TITLE
Retrieve remote layers uncompressed and implement remote delete.

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -296,7 +296,7 @@ func (i *Image) GetLayer(sha string) (io.ReadCloser, error) {
 		return nil, err
 	}
 
-	return layer.Compressed()
+	return layer.Uncompressed()
 }
 
 func (i *Image) AddLayer(path string) error {
@@ -361,16 +361,19 @@ func (i *Image) doSave(imageName string) error {
 	if err != nil {
 		return err
 	}
-
-	if err := remote.Write(ref, i.image, remote.WithAuth(auth)); err != nil {
-		return err
-	}
-
-	return nil
+	return remote.Write(ref, i.image, remote.WithAuth(auth))
 }
 
 func (i *Image) Delete() error {
-	return errors.New("remote image does not implement Delete")
+	id, err := i.Identifier()
+	if err != nil {
+		return err
+	}
+	ref, auth, err := referenceForRepoName(i.keychain, id.String())
+	if err != nil {
+		return err
+	}
+	return remote.Delete(ref, remote.WithAuth(auth))
 }
 
 type subImage struct {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -737,6 +737,38 @@ func testRemoteImage(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 	})
+
+	when("#Delete", func() {
+		when("it exists", func() {
+			var img imgutil.Image
+			it.Before(func() {
+				h.CreateImageOnRemote(t, dockerClient, repoName, fmt.Sprintf(`
+					FROM scratch
+					LABEL repo_name_for_randomisation=%s
+				`, repoName), nil)
+
+				var err error
+				img, err = remote.NewImage(
+					repoName, authn.DefaultKeychain,
+					remote.FromBaseImage(repoName),
+				)
+				h.AssertNil(t, err)
+			})
+
+			it("returns nil", func() {
+				h.AssertNil(t, img.Delete())
+			})
+		})
+
+		when("it does not exists", func() {
+			it("returns an error", func() {
+				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
+				h.AssertNil(t, err)
+
+				h.AssertError(t, img.Delete(), "Not Found")
+			})
+		})
+	})
 }
 
 func manifestLayers(t *testing.T, repoName string) []string {

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -755,8 +755,12 @@ func testRemoteImage(t *testing.T, when spec.G, it spec.S) {
 				h.AssertNil(t, err)
 			})
 
-			it("returns nil", func() {
-				h.AssertNil(t, img.Delete())
+			it("returns nil and is deleted", func() {
+				h.AssertEq(t, origImg.Found(), true)
+
+				h.AssertNil(t, origImg.Delete())
+
+				h.AssertEq(t, img.Found(), false)
 			})
 		})
 
@@ -765,6 +769,7 @@ func testRemoteImage(t *testing.T, when spec.G, it spec.S) {
 				img, err := remote.NewImage(repoName, authn.DefaultKeychain)
 				h.AssertNil(t, err)
 
+				h.AssertEq(t, img.Found(), false)
 				h.AssertError(t, img.Delete(), "Not Found")
 			})
 		})

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -756,9 +756,9 @@ func testRemoteImage(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("returns nil and is deleted", func() {
-				h.AssertEq(t, origImg.Found(), true)
+				h.AssertEq(t, img.Found(), true)
 
-				h.AssertNil(t, origImg.Delete())
+				h.AssertNil(t, img.Delete())
 
 				h.AssertEq(t, img.Found(), false)
 			})

--- a/testhelpers/docker_registry.go
+++ b/testhelpers/docker_registry.go
@@ -29,6 +29,7 @@ func (registry *DockerRegistry) Start(t *testing.T) {
 	ctx := context.Background()
 	ctr, err := DockerCli(t).ContainerCreate(ctx, &container.Config{
 		Image: "registry:2",
+		Env:   []string{"REGISTRY_STORAGE_DELETE_ENABLED=true"},
 	}, &container.HostConfig{
 		AutoRemove: true,
 		PortBindings: nat.PortMap{


### PR DESCRIPTION
The lifecycle image cache expects layers to be retrieved as uncompressed
tars and attempts to delete the original cache image when the new image
is written.