### PR TITLE
remote.Identifier parses the reponame accurately

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -163,12 +163,17 @@ func (i *Image) Found() bool {
 }
 
 func (i *Image) Identifier() (imgutil.Identifier, error) {
+	ref, err := name.ParseReference(i.repoName, name.WeakValidation)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse reference for image '%s': %s", i.repoName, err)
+	}
+
 	hash, err := i.image.Digest()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get digest for image '%s': %s", i.repoName, err)
 	}
 
-	digestRef, err := name.NewDigest(i.repoName+"@"+hash.String(), name.WeakValidation)
+	digestRef, err := name.NewDigest(fmt.Sprintf("%s@%s", ref.Context().Name(), hash.String()), name.WeakValidation)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating digest reference")
 	}

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -246,6 +246,20 @@ func testRemoteImage(t *testing.T, when spec.G, it spec.S) {
 			h.AssertEq(t, identifier.String(), repoName+"@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5")
 		})
 
+		it("accurately parses the reference for an image with a sha", func() {
+			var err error
+			img, err = remote.NewImage(
+				repoName+"@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5",
+				authn.DefaultKeychain,
+				remote.FromBaseImage("busybox@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5"),
+			)
+			h.AssertNil(t, err)
+
+			identifier, err := img.Identifier()
+			h.AssertNil(t, err)
+			h.AssertEq(t, identifier.String(), repoName+"@sha256:915f390a8912e16d4beb8689720a17348f3f6d1a7b659697df850ab625ea29d5")
+		})
+
 		when("the image has been modified and saved", func() {
 			it("returns the new digest reference", func() {
 				h.AssertNil(t, img.SetLabel("new", "label"))


### PR DESCRIPTION
Signed-off-by: Ashwin Venkatesh <avenkatesh@pivotal.io>
Signed-off-by: Matthew McNew <mmcnew@pivotal.io>